### PR TITLE
Replaces old v250 github workflow and script

### DIFF
--- a/.github/versions-to-build.txt
+++ b/.github/versions-to-build.txt
@@ -1,0 +1,5 @@
+# List versions to build (space or newline separated)
+# Example:
+# v250
+# v251
+v250

--- a/.github/workflows/build-hex.yml
+++ b/.github/workflows/build-hex.yml
@@ -1,4 +1,4 @@
-name: Build v250 HEX
+name: Build HEX
 
 on:
   workflow_dispatch:
@@ -6,18 +6,20 @@ on:
     paths:
       - "brWheel_my/**"
       - "arduino-1.8.5/**"
-      - ".github/workflows/build-v250.yml"
-      - ".github/scripts/build_v250.py"
+      - ".github/workflows/build-hex.yml"
+      - ".github/scripts/build_hex.py"
   pull_request:
     paths:
       - "brWheel_my/**"
       - "arduino-1.8.5/**"
-      - ".github/workflows/build-v250.yml"
-      - ".github/scripts/build_v250.py"
+      - ".github/workflows/build-hex.yml"
+      - ".github/scripts/build_hex.py"
 
 jobs:
-  build-v250:
+  build-hex:
     runs-on: windows-latest
+    env:
+      ZIP_PATH: build.zip
 
     steps:
       - name: Checkout
@@ -50,16 +52,16 @@ jobs:
           Copy-Item -Path "arduino-1.8.5\libraries\*" -Destination $libDir -Recurse -Force
           "ARDUINO_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Build v250 variants
+      - name: Build variants
         shell: pwsh
         run: |
-          python .github\scripts\build_v250.py
+          python .github\scripts\build_hex.py
 
-      - name: Upload v250 zip
+      - name: Upload build zip
         uses: actions/upload-artifact@v4
         with:
-          name: v250-hex-zip
-          path: dist/v250_hex.zip
+          name: build-hex-zip
+          path: ${{ env.ZIP_PATH }}
 
       - name: Commit rebuilt HEX files
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -67,10 +69,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "brWheel_my/leonardo hex/fw_v250" "brWheel_my/promicro hex/fw_v250"
+          $versions = $env:VERSIONS -split '[,\s]+' | Where-Object { $_ -ne '' }
+          foreach ($version in $versions) {
+            $leo = "brWheel_my/leonardo hex/fw_$version"
+            $pro = "brWheel_my/promicro hex/fw_$version"
+            if (Test-Path $leo) { git add "$leo" }
+            if (Test-Path $pro) { git add "$pro" }
+          }
           $status = git status --porcelain
           if ($status) {
-            git commit -m "chore: rebuild v250 hex"
+            git commit -m "chore: rebuild hex"
             git push
           } else {
             Write-Host "No changes to commit."

--- a/.github/workflows/build-hex.yml
+++ b/.github/workflows/build-hex.yml
@@ -52,6 +52,21 @@ jobs:
           Copy-Item -Path "arduino-1.8.5\libraries\*" -Destination $libDir -Recurse -Force
           "ARDUINO_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      - name: Load versions to build
+        shell: pwsh
+        run: |
+          $versionsFile = ".github/versions-to-build.txt"
+          if (-not (Test-Path $versionsFile)) {
+            throw "Missing $versionsFile; expected at least one version like v250."
+          }
+          $versionsValue = (Get-Content $versionsFile |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -and -not $_.StartsWith("#") }) -join " "
+          if (-not $versionsValue) {
+            throw "No versions found in $versionsFile."
+          }
+          "VERSIONS=$versionsValue" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Build variants
         shell: pwsh
         run: |
@@ -64,11 +79,12 @@ jobs:
           path: ${{ env.ZIP_PATH }}
 
       - name: Commit rebuilt HEX files
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         shell: pwsh
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
           $versions = $env:VERSIONS -split '[,\s]+' | Where-Object { $_ -ne '' }
           foreach ($version in $versions) {
             $leo = "brWheel_my/leonardo hex/fw_$version"
@@ -76,6 +92,7 @@ jobs:
             if (Test-Path $leo) { git add "$leo" }
             if (Test-Path $pro) { git add "$pro" }
           }
+
           $status = git status --porcelain
           if ($status) {
             git commit -m "chore: rebuild hex"

--- a/brWheel_my/brWheel_my.ino
+++ b/brWheel_my/brWheel_my.ino
@@ -456,7 +456,7 @@ void loop() {
 #endif // end of proMicro
 #else // if no avg
 #ifndef USE_SPLITAXIS
-        //accel.val = analogRead(ACCEL_PIN); // milos, Z axis
+        accel.val = analogRead(ACCEL_PIN); // milos, Z axis
 #else // milos, use combined axis for gas and brake
 #ifdef USE_QUADRATURE_ENCODER // milos, when using optical encoder
         combinedAxis = analogRead(ACCEL_PIN); // milos, store accelerator into temporary axis

--- a/brWheel_my/brWheel_my.ino
+++ b/brWheel_my/brWheel_my.ino
@@ -456,7 +456,7 @@ void loop() {
 #endif // end of proMicro
 #else // if no avg
 #ifndef USE_SPLITAXIS
-        accel.val = analogRead(ACCEL_PIN); // milos, Z axis
+        //accel.val = analogRead(ACCEL_PIN); // milos, Z axis
 #else // milos, use combined axis for gas and brake
 #ifdef USE_QUADRATURE_ENCODER // milos, when using optical encoder
         combinedAxis = analogRead(ACCEL_PIN); // milos, store accelerator into temporary axis


### PR DESCRIPTION
### Summary

- Introduces `.github/scripts/build_hex.py` which reads version names from `.github/versions-to-build.txt`, toggles the right `Config.h` defines per variant, writes the compiled HEX back into the matching folder, and archives everything into `build.zip`.

### Instructions

- Edit `.github/versions-to-build.txt` (space- or newline-separated) to add/remove version folders. The workflow uses that list, so no manual workflow changes are required.
- When the workflow runs it skips any version without existing `fw_<version>` folders and prints "Skipping <version>".
- Place placeholder HEX filenames inside the version folder beforehand; the script overwrites them when the build succeeds.
`apply_options` is the place where the filename suffix `/v<version><letters>` gets translated into toggles in `Config.h`.


**Special-letter handlers:**

- `"n"` or `"r"` toggles shift-register support.
- `"r"` additionally turns on `USE_SN74ALS166N`.
- `"p"` means “no EEPROM,” so we treat its absence as “enable EEPROM.”
- `"d"` or `"w"` turn off the optical encoder (the quadrature encoder define).
- `promicro` is inferred from the caller (the Micro build always sets `promicro=True`).

**How to add extra logic**

If you want to support a letter that doesn’t map to a single `#define`, extend `apply_options` with whatever logic you need. For example:

```C
if "m" in letters:
   updated = set_define(updated, "USE_MY_FEATURE", True)
   updated = set_define(updated, "USE_OTHER_FEATURE", False)
```

You can also use other letters to flip multiple defines, set pins, or adjust constants—just add the corresponding code before returning the modified lines.

### Testing

- Run the workflow via GitHub Actions → Build HEX.
- Download the `build-hex-zip` artifact to verify the rebuilt HEX files.